### PR TITLE
java: Specify heap size for metalava for R

### DIFF
--- a/java/droiddoc.go
+++ b/java/droiddoc.go
@@ -1468,6 +1468,7 @@ func metalavaCmd(ctx android.ModuleContext, rule *android.RuleBuilder, javaVersi
 
 	cmd.BuiltTool(ctx, "metalava").
 		Flag(config.JavacVmFlags).
+		Flag("-J-Xmx3112m").
 		FlagWithArg("-encoding ", "UTF-8").
 		FlagWithArg("-source ", javaVersion.String()).
 		FlagWithRspFileInputList("@", srcs).


### PR DESCRIPTION
Works fine for low ram systems to compile R.